### PR TITLE
fix: unable read cert from file

### DIFF
--- a/src/Lazvard.Message.Cli/Configuration.cs
+++ b/src/Lazvard.Message.Cli/Configuration.cs
@@ -207,6 +207,7 @@ public sealed class Configuration
 
             result.IP = config[ConfigurationSections.Server][nameof(BrokerConfig.IP)]?.AsString ?? result.IP;
             result.Port = config[ConfigurationSections.Server][nameof(BrokerConfig.Port)]?.AsInteger ?? result.Port;
+            result.UseBuiltInCertificateManager = config[ConfigurationSections.Server][nameof(CliConfig.UseBuiltInCertificateManager)].AsBoolean ?? result.UseBuiltInCertificateManager;
             result.CertificatePath = config[ConfigurationSections.Server][nameof(CliConfig.CertificatePath)].AsString;
             result.CertificatePassword = config[ConfigurationSections.Server][nameof(CliConfig.CertificatePassword)].AsString;
 


### PR DESCRIPTION
`UseBuiltInCertificateManager` is not read from `config.toml` making it impossible to read the certificate from file.